### PR TITLE
Fixed elements regex

### DIFF
--- a/includes/class-models.php
+++ b/includes/class-models.php
@@ -881,7 +881,7 @@ if ( ! class_exists( 'Tailor_Models' ) ) {
 	    public function generate_element_regex() {
 		    $element_types = array();
 		    foreach ( tailor_elements()->get_elements() as $element ) {
-			    $element_types[] = str_replace( 'tailor_', '', $element->tag );
+			    $element_types[] = $element->tag;
 		    }
 		    $this->regex = sprintf(
 			    "/<!--" .
@@ -935,7 +935,7 @@ if ( ! class_exists( 'Tailor_Models' ) ) {
 				    $content = $matches[5][ $i ];
 				    $model = array(
 					    'id'            =>  $id,
-					    'tag'           =>  'tailor_' . $type,
+					    'tag'           =>  $type,
 					    'atts'          =>  array(),
 					    'parent'        =>  $parent,
 					    'order'         =>  $i,


### PR DESCRIPTION
Strip out `tailor_` prefix from element tag when generating element regex makes custom elements not identified when generating models from post content as I mentioned in #138 

This changes will fix the issue.