### PR TITLE
Ghost shortcode

### DIFF
--- a/includes/class-elements.php
+++ b/includes/class-elements.php
@@ -336,7 +336,40 @@ if ( ! class_exists( 'Tailor_Elements' ) ) {
 
 		    if ( isset( $element ) ) {
 			    $this->elements[ $element->tag ] = $element;
+			    $this->register_shortcode_if_not_exists( $tag );
 		    }
+	    }
+	    
+	    /**
+	     * Create shortcode if it doesn't exists, based on element tag.
+	     *
+	     * @access public
+	     *
+	     * @param string $tag
+	     *
+	     * @return array
+	     */
+	    public function register_shortcode_if_not_exists( $tag ) {
+		    global $shortcode_tags;
+
+		    if ( ! array_key_exists( $tag, $shortcode_tags ) ) {
+		    	add_shortcode( $tag, array( $this, 'print_element_shortcode') );
+		    }
+	    }
+	    
+	    /**
+	     * Render the shortcode.
+	     *
+	     * @access public
+	     *
+	     * @param array $atts
+	     * @param string $content
+	     * @param string $tag
+	     *
+	     * @return array
+	     */
+	    public function print_element_shortcode( $atts, $content = '', $tag ) {
+	    	return apply_filters( "tailor_render_element_shortcode_{$tag}", '', $atts, $content );
 	    }
 	    
 	    /**

--- a/includes/class-models.php
+++ b/includes/class-models.php
@@ -881,7 +881,7 @@ if ( ! class_exists( 'Tailor_Models' ) ) {
 	    public function generate_element_regex() {
 		    $element_types = array();
 		    foreach ( tailor_elements()->get_elements() as $element ) {
-			    $element_types[] = str_replace( 'tailor_', '', $element->tag );
+			    $element_types[] = $element->tag;
 		    }
 		    $this->regex = sprintf(
 			    "/<!--" .
@@ -935,7 +935,7 @@ if ( ! class_exists( 'Tailor_Models' ) ) {
 				    $content = $matches[5][ $i ];
 				    $model = array(
 					    'id'            =>  $id,
-					    'tag'           =>  'tailor_' . $type,
+					    'tag'           =>  $type,
 					    'atts'          =>  array(),
 					    'parent'        =>  $parent,
 					    'order'         =>  $i,


### PR DESCRIPTION
Currently, we have to register the shortcode when registering element but if we register the element within a theme then it's a fault based on theme check plugin because using `add_shortcode` function is plugin territory.

This change makes it easier to create a custom element directly from a theme without having to register the shortcode just what Visual Composer plugin does.

To render the shortcode just simply add filter to `tailor_render_element_shortcode_{TAG}`, example:

```
function render_custom_shortcode($default, $atts, $content = '') {
    // do stuff here
}

add_filter('tailor_render_element_shortcode_custom', 'render_custom_shortcode', 10, 3);
```