### PR TITLE
Add higher priority on generating element regex

### DIFF
--- a/includes/class-models.php
+++ b/includes/class-models.php
@@ -59,7 +59,7 @@ if ( ! class_exists( 'Tailor_Models' ) ) {
 	     */
 	    protected function add_actions() {
 
-		    add_action( 'tailor_register_elements', array( $this, 'generate_element_regex' ) );
+		    add_action( 'tailor_register_elements', array( $this, 'generate_element_regex' ), 999 );
 		    //add_action( 'wp', array( $this, 'generate_models' ) );
 		    
 		    // Print model data


### PR DESCRIPTION
Currently, we add an action to generate element regex at default priority `10` means it's possible to occur before custom elements are registered.

By putting higher priority e.g `999` it will make sure that generate regex action will be fired at the very end of `tailor_register_elements` hook.