### PR TITLE
Update tailor.php

### DIFF
--- a/tailor.php
+++ b/tailor.php
@@ -468,7 +468,7 @@ if ( ! class_exists( 'Tailor' ) ) {
 		        
 		        wp_enqueue_style(
 			        'tailor-styles',
-			        $stylesheet_path,
+			        str_replace('http:','',$stylesheet_path),
 			        array(),
 			        $this->version()
 		        );


### PR DESCRIPTION
Remove the protocol from the enqueued URL for multisites that force HTTPS through a plugin but not through the default site URL.  We use Multisite with Multidomain Mapping.  This is the only way we could make it so the script loads over https.